### PR TITLE
filter extra fields that prevent table creation

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -184,6 +184,7 @@ function filterTable(table) {
   delete table.TableArn;
   delete table.LatestStreamLabel;
   delete table.LatestStreamArn;
+  delete table.TableId;
 
   (table.LocalSecondaryIndexes || []).forEach(index => {
     delete index.IndexSizeBytes;
@@ -196,6 +197,7 @@ function filterTable(table) {
     delete index.IndexSizeBytes;
     delete index.ItemCount;
     delete index.IndexArn;
+    delete index.ProvisionedThroughput.NumberOfDecreasesToday;
   });
 }
 


### PR DESCRIPTION
Not sure when it got added or unsupported, but using AWS SDK 2.5 and 2.82 I get a parameter validation error with table.TableId being present.

I'm also using autoscaling on the tables, which I think exposed another field (but I bet hasn't caught all of them yet); index.ProvisionedThroughput.NumberOfDecreasesToday can't be in the AWS call to create the table, either.

Thanks for writing this!