### PR TITLE
add dry run mode

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -42,7 +42,7 @@ const cli = meow(`
       --ca-file Set SSL certificate authority file
       --marshall Converts JSON to/from DynamoDB record on import/export
       --endpoint Endpoint URL for DynamoDB Local
-      --dry-run Simulate command 
+      --dry-run Report the actions that would be made without actually runnning them.
 
     Examples
       dynamodump export-schema --region=eu-west-1 --table=your-table --file=your-schema-dump


### PR DESCRIPTION
Solves #24 


Example
```
dynamodump export-data --region ap-southeast-1 --table xef --dry-run
Exporting data for table xef

dynamodump export-schema --region ap-southeast-1 --table test --dry-run
Exporting schema for table test

dynamodump import-schema --region ap-southeast-1 --table test-test --dry-run --file test
Exporting schema for table test-test

dynamodump import-schema --region ap-southeast-1 --table test-test --dry-run --file test
Importing schema for table test-test from file test

dynamodump export-all-schema --region ap-southeast-1 --dry-run
Exporting schema for table table1
Exporting schema for table table2
Exporting schema for table table3

```